### PR TITLE
fix: accurate TARGET_IO_PORT masks from config.h

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -1105,31 +1105,23 @@ echo '' >> ${hFile}
 
 # port masks
 echo "building port masks"
-if [[ $(grep ' PA[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTA 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PB[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTB 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PB[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTC 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PD[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTD 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PE[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTE 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PF[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTF 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PG[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTG 0xffff' >> ${hFile}
-fi
-if [[ $(grep ' PH[0-9]' $config) ]]; then
-    echo '#define TARGET_IO_PORTH 0xffff' >> ${hFile}
-fi
-echo '// notice - masks were programmatically generated - please verify last port group for 0xffff or (BIT(2))' >> ${hFile}
+
+# Compute per-port bitmasks by scanning every P[A-H][0-9]{1,2} token in config.h.
+# Each bit N in TARGET_IO_PORTx represents pin N (0-15): (1 << N).
+declare -A portMask
+while IFS= read -r pinToken; do
+    port="${pinToken:1:1}"
+    num="${pinToken:2}"
+    portMask[$port]=$(( ${portMask[$port]:-0} | (1 << num) ))
+done < <(grep -oE '\bP[A-H][0-9]{1,2}\b' "$config" | sort -u)
+
+for port in A B C D E F G H; do
+    mask="${portMask[$port]}"
+    if [[ -n "$mask" && "$mask" -ne 0 ]]; then
+        printf '#define TARGET_IO_PORT%s 0x%04x\n' "$port" "$mask" >> "${hFile}"
+    fi
+done
+echo '// notice - port masks computed from pin usage in config.h' >> ${hFile}
 echo '' >> ${hFile}
 
 echo "building static default FEATURES"

--- a/convert.sh
+++ b/convert.sh
@@ -1118,10 +1118,16 @@ done < <(grep -oE '\bP[A-H][0-9]{1,2}\b' "$config" | sort -u)
 for port in A B C D E F G H; do
     mask="${portMask[$port]}"
     if [[ -n "$mask" && "$mask" -ne 0 ]]; then
-        printf '#define TARGET_IO_PORT%s 0x%04x\n' "$port" "$mask" >> "${hFile}"
+        # Single-pin port (mask is a power of 2): emit exact BIT(n).
+        # Multi-pin port: emit 0xffff so future pin additions never require mask edits.
+        if (( (mask & (mask - 1)) == 0 )); then
+            printf '#define TARGET_IO_PORT%s 0x%04x\n' "$port" "$mask" >> "${hFile}"
+        else
+            printf '#define TARGET_IO_PORT%s 0xffff\n' "$port" >> "${hFile}"
+        fi
     fi
 done
-echo '// notice - port masks computed from pin usage in config.h' >> ${hFile}
+echo '// notice - port masks derived from config.h; single-pin ports use exact mask, multi-pin ports use 0xffff' >> ${hFile}
 echo '' >> ${hFile}
 
 echo "building static default FEATURES"

--- a/convert.sh
+++ b/convert.sh
@@ -1121,7 +1121,8 @@ for port in A B C D E F G H; do
         # Single-pin port (mask is a power of 2): emit exact BIT(n).
         # Multi-pin port: emit 0xffff so future pin additions never require mask edits.
         if (( (mask & (mask - 1)) == 0 )); then
-            printf '#define TARGET_IO_PORT%s 0x%04x\n' "$port" "$mask" >> "${hFile}"
+            pin_num=0; while (( (1 << pin_num) != mask )); do (( pin_num++ )); done
+            printf '#define TARGET_IO_PORT%s (BIT(%d))\n' "$port" "$pin_num" >> "${hFile}"
         else
             printf '#define TARGET_IO_PORT%s 0xffff\n' "$port" >> "${hFile}"
         fi


### PR DESCRIPTION
## Summary

- Replaces blind `0xffff` for all ports with computed masks derived from pin usage in `config.h`
- Fixes a pre-existing copy-paste bug where `TARGET_IO_PORTC` was checked with `grep ' PB[0-9]'` (same as PORTB), so PORTC was always `0xffff` whenever PORTB was present, regardless of actual PC pin usage
- Convention followed: multi-pin ports → `0xffff` (future-proof, no mask maintenance when adding peripherals); single-pin ports → `BIT(n)` (matches community convention, e.g. `TARGET_IO_PORTD (BIT(2))` for PD2/BEEPER)
- `BIT(n)` derivation is generic — correctly handles any pin 0–15, not just PD2

## How it works

Scans all `P[A-H][0-9]{1,2}` tokens in `config.h`, groups by port letter, ORs `(1 << pin_number)` per port. If the resulting mask has exactly one bit set (power-of-2 check), emits `(BIT(n))`; otherwise emits `0xffff`.

## Example output (FOXEERF722V4, TMOTORF7, PYRODRONEF7, TUNERCF405, SKYSTARSF405AIO)

```c
#define TARGET_IO_PORTA 0xffff
#define TARGET_IO_PORTB 0xffff
#define TARGET_IO_PORTC 0xffff
#define TARGET_IO_PORTD (BIT(2))
```

## Test plan

- [ ] Run all five test targets and confirm mask output matches above
- [ ] Confirm a target with no PD pins emits no PORTD line
- [ ] Confirm a target with multiple PD pins emits `0xffff` for PORTD

## Merge order

**Requires PR #8 (`research/no-unified-targets` → `master`) to be merged first.**
After PR #8 merges, rebase or change this PR's base to `master` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)