### PR TITLE
docs: track info/ reference docs and .github/instructions

### DIFF
--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: "**"
+---
+
+# target-convert Development Rules
+
+## Branches
+
+- Never commit directly to `master`. All changes go on a feature branch.
+- One branch per logical concern. MCU family additions get their own branch: `feat/h7-support`, `feat/g4-support`, `feat/at32-support`.
+- Stacked PRs: after upstream merges, rebase with `git rebase --onto master <old-base> <branch>`.
+
+## Merging
+
+- Always squash-merge: `gh pr merge <N> --squash`
+- Never use `--delete-branch`. GitHub auto-closes any PR whose base branch is deleted.
+
+## .gitignore is a pure whitelist
+
+The root `.gitignore` starts with `/*` (block everything) and uses only `!allowlist` entries. Never add a specific blocklist entry inside it.
+
+- To untrack a file: `git rm --cached <file>` — that is sufficient. Do not add the filename to `.gitignore`.
+- To track files in a new directory: add both `!dir/` and `!dir/*` to `.gitignore` (both are required — `/*` blocks the directory itself, preventing git from entering it without the explicit `!dir/` entry).
+
+## Commits
+
+- Format: `type: subject` (~50 chars, imperative mood)
+- Types: `feat`, `fix`, `refactor`, `style`, `docs`, `chore`, `build`
+- Always add: `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+
+## Testing before merge
+
+Run all five reference targets and verify output:
+```
+./convert.sh FOXEERF722V4 ./test
+./convert.sh TUNERCF405 ./test
+./convert.sh TMOTORF7 ./test
+./convert.sh PYRODRONEF7 ./test
+./convert.sh SKYSTARSF405AIO ./test
+```
+
+Check: port masks match convention (`0xffff` multi-pin, `(BIT(n))` single-pin), timers resolve, no aborts.
+
+## Scope
+
+This repo converts Betaflight `config.h` files to EmuFlight target files. Changes are limited to `convert.sh` and `lookup/*.csv`. Do not modify EmuFlight source directly.

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 !.gitignore
 !README.md
 !convert.sh
+!info/
 !info/*
 !lookup/
 !lookup/*
+!.github/
+!.github/instructions/
+!.github/instructions/*

--- a/info/CONVERTER_DESIGN.md
+++ b/info/CONVERTER_DESIGN.md
@@ -1,0 +1,101 @@
+# Converter Design Notes
+
+## Source of truth: betaflight/config
+
+All target definitions are fetched from:
+```
+https://github.com/betaflight/config/raw/master/configs/<TARGETNAME>/config.h
+```
+
+The old `betaflight/unified-targets` repo (`.config` files, `VEND-TARGETNAME` format) is no longer used. The `betaflight/config` repo organizes by bare target name (`TUNERCF405/config.h`), which is why the vendor prefix is no longer required as input.
+
+## Input format
+
+```
+./convert.sh <TARGETNAME> [outputFolder]
+```
+
+- `TARGETNAME` = bare board name matching a directory in `betaflight/config/configs/`
+- `outputFolder` = optional, defaults to `./`
+- Previously required `VEND-TARGETNAME` format (e.g. `TURC-TUNERCF405`) — no longer needed
+
+## Lookup tables (lookup/*.csv)
+
+CSV format: comma-separated, `#` comment lines skipped.
+
+### Timer hardware tables (`f4_timer_hw.csv`, `f7_timer_hw.csv`)
+
+```
+# pin,occurrence,TIM,CH
+PA0,1,TIM2,CH1
+PA0,2,TIM5,CH1
+```
+
+- `occurrence` = which timer this pin maps to in priority order (matches the occurrence index in Betaflight's `TIMER_PIN_MAP`)
+- Generated from `timer_stm32f4xx.c` / `timer_stm32f7xx.c` in the Betaflight source
+- Key in associative array: `PIN_occurrence` → `TIMx:CHy`
+
+### DMA tables (`f4f7_dma_adc.csv`, `f4f7_dma_timer.csv`, `f4f7_dma_spi.csv`)
+
+```
+# ADCdev,opt,ctrl,stream,channel
+1,0,2,0,0
+```
+
+- `opt` = dmaopt value from `TIMER_PIN_MAP` or `ADCn_DMA_OPT` in config.h
+- `ctrl`/`stream`/`channel` = DMA controller number, stream, channel
+
+### Generating/updating lookup tables
+
+See `tools/gen_lookup_tables.sh` — requires a local Betaflight source tree.
+
+## Timer resolution (TIMER_PIN_MAP)
+
+Betaflight `config.h` contains:
+```c
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP(0, PA9,  1, -1) \
+    TIMER_PIN_MAP(1, PA8,  1,  0)
+```
+
+Format: `TIMER_PIN_MAP(index, PIN, occurrence, dmaopt)`
+
+The converter:
+1. Parses all `TIMER_PIN_MAP()` entries from `config.h`
+2. Looks up `PIN + occurrence` in the timer CSV to get `TIMx:CHy`
+3. Determines `TIM_USE_*` role from pin's define in config.h (MOTOR_PIN, PPM_PIN, LED_STRIP_PIN, CAMERA_CONTROL_PIN)
+4. Emits `DEF_TIM(TIMx, CHy, PIN, TIM_USE_xxx, 0, dmaopt)` in `target.c`
+
+## GYRO SPI naming
+
+EmuFlight uses:
+- `GYRO_1_SPI_BUS` / `GYRO_2_SPI_BUS` (not `_SPI_INSTANCE`)
+- `SPIDEV_1` through `SPIDEV_4` (not `SPI1` through `SPI4`)
+
+Betaflight config.h uses `GYRO_1_SPI_INSTANCE` and `SPI1`. The converter translates automatically via `sed`.
+
+## SPI pin naming
+
+Betaflight config.h uses `SPIn_SDI_PIN` / `SPIn_SDO_PIN` (MISO/MOSI in newer naming).
+EmuFlight uses `SPIn_MISO_PIN` / `SPIn_MOSI_PIN`.
+The converter translates these automatically.
+
+## Output files
+
+| File | Description |
+|------|-------------|
+| `TARGETNAME/target.mk` | Build system: MCU target group, VCP/flash features, driver sources |
+| `TARGETNAME/target.c` | Timer hardware array (`timerHardware[]`) with `DEF_TIM()` entries |
+| `TARGETNAME/target.h` | All `#define` pin/feature definitions |
+| `TARGETNAME/resources/config.h` | Downloaded Betaflight config (reference) |
+| `TARGETNAME/resources/timers.txt` | Human-readable timer summary (reference) |
+
+## Known limitations / manual review required
+
+- Dual-gyro targets: GYRO_1/GYRO_2 pin assignments may need validation
+- SPI RX (ELRS, FrSky): partially automated, manual completion needed
+- VTX RTC6705: skipped entirely, add manually if needed
+- GPS: skipped
+- ADC DMA streams: computed but marked with "please verify"
+- Some rare peripheral combinations not accounted for
+- Always search output files for the keyword `notice` to find items needing manual attention

--- a/info/PORT_MASKS.md
+++ b/info/PORT_MASKS.md
@@ -1,0 +1,53 @@
+# TARGET_IO_PORT Masks
+
+## What they are
+
+`TARGET_IO_PORTA`, `TARGET_IO_PORTB`, etc. are bitmasks defined in `target.h`. Each bit N represents whether pin N (0–15) on that port is accessible to the firmware.
+
+```c
+#define TARGET_IO_PORTA 0xffff   // all 16 PA pins available
+#define TARGET_IO_PORTD (BIT(2)) // only PD2 available
+```
+
+`BIT(n)` = `(1 << n)`, defined in EmuFlight/Betaflight common headers.
+
+## How the firmware uses them (DEFIO system)
+
+The Perl script `src/utils/def_generated.pl` generates `io_def_generated.h` at build time. For each port/pin combination it checks the mask:
+
+```c
+#if DEFIO_PORT_A_USED_MASK & BIT(5)
+  #define DEFIO_TAG__PA5  DEFIO_TAG_MAKE(...)
+#else
+  #define DEFIO_TAG__PA5  defio_error_PA5_is_not_supported_on_TARGET
+#endif
+```
+
+**Consequence:** if a pin is referenced anywhere in the target's code but its bit is NOT set in the mask, the build fails with a compile error (`defio_error_Pxx_is_not_supported_on_TARGET` expands as an undefined identifier). This is intentional — it's a compile-time safety gate.
+
+## Convention
+
+- **Multi-pin port (2+ pins used):** always `0xffff`
+  - All 16 pins on that port are declared available
+  - Future peripheral additions never require mask edits
+  - Slight memory overhead (a few bytes in `ioRec[]` array) — irrelevant in practice
+- **Single-pin port (exactly 1 pin used):** `(BIT(n))` where n is the pin number
+  - Example: PD2 (BEEPER on most F4/F7 boards) → `TARGET_IO_PORTD (BIT(2))`
+  - Accurately reflects that the rest of the port isn't routed out on this hardware
+
+## Why 0xffff is always safe
+
+`0xffff` on a port that only has 1–2 pins routed out works fine. The extra pin descriptors in `ioRec[]` simply go unused. No runtime effect. This is why targets with `0xffff` on all ports (including PORTD) have always worked — pilots never noticed because there's no functional difference.
+
+## How convert.sh computes masks
+
+1. Scans `config.h` for all `P[A-H][0-9]{1,2}` tokens
+2. Groups by port letter, ORs `(1 << pin_number)` per port
+3. Power-of-2 check `(mask & (mask-1)) == 0` → single pin → emit `(BIT(n))`
+4. Otherwise emit `0xffff`
+
+## Port letters by MCU family
+
+- F4, F7: ports A–H (some boards only use A–D or A–E)
+- H7: ports A–K (adds I, J, K) — needs extension when H7 support is added
+- G4: ports A–G typically


### PR DESCRIPTION
## Summary

- Tracks `info/PORT_MASKS.md` — reference on TARGET_IO_PORT mask behavior, DEFIO system, BIT(n) convention
- Tracks `info/CONVERTER_DESIGN.md` — reference on config.h parsing, lookup CSV format, timer resolution, output file structure, known limitations
- Tracks `.github/instructions/workflow.instructions.md` — AI-actionable rules for branch/merge/commit/test conventions (GitHub Copilot workspace instructions format)
- Updates `.gitignore` whitelist: adds `!info/` directory entry (required alongside existing `!info/*`) and `.github/instructions/` entries

## Not included

- `USE_.txt` was already tracked
- `PLAN_no-unified-targets.md`, `MCU_ROADMAP.md` remain untracked at `./` (project direction/history, not user reference)

## Test plan

- [ ] Confirm `info/PORT_MASKS.md`, `info/CONVERTER_DESIGN.md`, `.github/instructions/workflow.instructions.md` appear in the diff
- [ ] Confirm `git status` clean after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)