### PR TITLE
chore: add CLAUDE.md and AGENTS.md project agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # Includelist some files
 !.gitignore
 !README.md
+!CLAUDE.md
+!AGENTS.md
 !convert.sh
 !info/
 !info/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+## Project Overview
+`target-convert` converts Betaflight `config.h` files to EmuFlight target files. Source of truth is `https://github.com/betaflight/config/raw/master/configs/<TARGETNAME>/config.h`. The old `betaflight/unified-targets` repo is no longer used.
+
+## Scope
+Changes are limited to `convert.sh` and `lookup/*.csv`. Do not modify EmuFlight source directly.
+
+## Key Technical Concepts
+
+### TIMER_PIN_MAP
+Betaflight `config.h` defines timers as:
+```
+TIMER_PIN_MAP(index, PIN, occurrence, dmaopt)
+```
+- `occurrence` selects which timer this pin maps to (priority order, see `lookup/*.csv`)
+- `dmaopt` selects DMA stream; `-1` means no DMA (input capture only)
+- Pin values may be macro names (e.g. `MOTOR1_PIN`) that must be resolved via `#define` lookup in config.h before timer table lookup
+- Filter comment lines (`^\s*//`) from TIMER_PIN_MAP grep — some targets include a header comment that matches the pattern
+
+### Port Masks
+`TARGET_IO_PORTx` bitmasks define which pins are accessible to firmware (DEFIO compile-time safety gate):
+- **Multi-pin port (2+ pins used):** always `0xffff`
+- **Single-pin port (exactly 1 pin):** `BIT(n)` where n is the pin number
+- `0xffff` on a lightly-used port is always safe; extra `ioRec[]` entries go unused at runtime
+- See `info/PORT_MASKS.md` for full documentation
+
+### EmuFlight vs Betaflight Naming
+| Betaflight | EmuFlight |
+|---|---|
+| `GYRO_1_SPI_INSTANCE` | `GYRO_1_SPI_BUS` |
+| `SPI1`…`SPI4` | `SPIDEV_1`…`SPIDEV_4` |
+| `SPIn_SDI_PIN` | `SPIn_MISO_PIN` |
+| `SPIn_SDO_PIN` | `SPIn_MOSI_PIN` |
+
+### Lookup Tables (`lookup/*.csv`)
+Format: comma-separated, `#` comment lines skipped.
+
+| File | Key | Value |
+|---|---|---|
+| `f4_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` |
+| `f7_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` |
+| `h7_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` — H7 has TIM15/16/17 instead of F7's TIM9/10/11 |
+| `f4f7_dma_timer.csv` | timer DMA stream assignments | |
+| `f4f7_dma_adc.csv` | `ADCdev,opt` | DMA controller/stream |
+| `f4f7_dma_spi.csv` | SPI DMA stream assignments | |
+
+### MCU Family Routing
+| Betaflight MCU | Timer CSV | `TARGET_BOARD_IDENTIFIER` | Make target group |
+|---|---|---|---|
+| STM32F405 | f4 | `S405` | `F405_TARGETS` |
+| STM32F411 | f4 | `S411` | `F411_TARGETS` |
+| STM32F7X2 | f7 | `S7X2` | `F7X2RE_TARGETS` |
+| STM32F745 | f7 | `S745` | `F7X5XG_TARGETS` |
+| STM32H743 | h7 | `SH74` | `H743_TARGETS` |
+| STM32H750 | h7 | `S750` | `H750_TARGETS` |
+
+## Testing
+Run all five reference targets and verify output (no aborts, port masks match convention):
+```
+./convert.sh FOXEERF722V4 ./test
+./convert.sh TUNERCF405 ./test
+./convert.sh TMOTORF7 ./test
+./convert.sh PYRODRONEF7 ./test
+./convert.sh SKYSTARSF405AIO ./test
+```
+Check: port masks are `0xffff` for multi-pin ports and `(BIT(n))` for single-pin ports, timers resolve (no `UNKNOWN_TIM`), no aborts.
+
+## Known Limitations
+- H7 ADC DMA streams: not resolved (H7 uses DMAMUX, not fixed assignments); output includes "please verify" notices
+- Dual-gyro targets: GYRO_1/GYRO_2 assignments may need post-convert validation
+- SPI RX (ELRS, FrSky): partial automation; manual completion needed
+- GPS: skipped entirely
+- VTX RTC6705: skipped; add manually if needed
+- `DEFAULT_VOLTAGE_METER_SCALE` not captured (pre-existing gap)
+- `USB_DETECT_PIN` define not emitted alongside `USE_USB_DETECT` (pre-existing gap)
+- Always search output files for keyword `notice` to find items needing manual attention

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,62 +1,17 @@
 # AGENTS.md
 
-## Project Overview
-`target-convert` converts Betaflight `config.h` files to EmuFlight target files. Source of truth is `https://github.com/betaflight/config/raw/master/configs/<TARGETNAME>/config.h`. The old `betaflight/unified-targets` repo is no longer used.
+## Project
+`target-convert` converts Betaflight `config.h` board definitions into EmuFlight target files (`target.mk`, `target.c`, `target.h`) using local CSV lookup tables. See technical details below.
 
 ## Scope
 Changes are limited to `convert.sh` and `lookup/*.csv`. Do not modify EmuFlight source directly.
 
-## Key Technical Concepts
-
-### TIMER_PIN_MAP
-Betaflight `config.h` defines timers as:
-```
-TIMER_PIN_MAP(index, PIN, occurrence, dmaopt)
-```
-- `occurrence` selects which timer this pin maps to (priority order, see `lookup/*.csv`)
-- `dmaopt` selects DMA stream; `-1` means no DMA (input capture only)
-- Pin values may be macro names (e.g. `MOTOR1_PIN`) that must be resolved via `#define` lookup in config.h before timer table lookup
-- Filter comment lines (`^\s*//`) from TIMER_PIN_MAP grep — some targets include a header comment that matches the pattern
-
-### Port Masks
-`TARGET_IO_PORTx` bitmasks define which pins are accessible to firmware (DEFIO compile-time safety gate):
-- **Multi-pin port (2+ pins used):** always `0xffff`
-- **Single-pin port (exactly 1 pin):** `BIT(n)` where n is the pin number
-- `0xffff` on a lightly-used port is always safe; extra `ioRec[]` entries go unused at runtime
-- See `info/PORT_MASKS.md` for full documentation
-
-### EmuFlight vs Betaflight Naming
-| Betaflight | EmuFlight |
-|---|---|
-| `GYRO_1_SPI_INSTANCE` | `GYRO_1_SPI_BUS` |
-| `SPI1`…`SPI4` | `SPIDEV_1`…`SPIDEV_4` |
-| `SPIn_SDI_PIN` | `SPIn_MISO_PIN` |
-| `SPIn_SDO_PIN` | `SPIn_MOSI_PIN` |
-
-### Lookup Tables (`lookup/*.csv`)
-Format: comma-separated, `#` comment lines skipped.
-
-| File | Key | Value |
-|---|---|---|
-| `f4_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` |
-| `f7_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` |
-| `h7_timer_hw.csv` | `PIN,occurrence` | `TIM,CH` — H7 has TIM15/16/17 instead of F7's TIM9/10/11 |
-| `f4f7_dma_timer.csv` | timer DMA stream assignments | |
-| `f4f7_dma_adc.csv` | `ADCdev,opt` | DMA controller/stream |
-| `f4f7_dma_spi.csv` | SPI DMA stream assignments | |
-
-### MCU Family Routing
-| Betaflight MCU | Timer CSV | `TARGET_BOARD_IDENTIFIER` | Make target group |
-|---|---|---|---|
-| STM32F405 | f4 | `S405` | `F405_TARGETS` |
-| STM32F411 | f4 | `S411` | `F411_TARGETS` |
-| STM32F7X2 | f7 | `S7X2` | `F7X2RE_TARGETS` |
-| STM32F745 | f7 | `S745` | `F7X5XG_TARGETS` |
-| STM32H743 | h7 | `SH74` | `H743_TARGETS` |
-| STM32H750 | h7 | `S750` | `H750_TARGETS` |
+## Technical Reference
+@info/CONVERTER_DESIGN.md
+@info/PORT_MASKS.md
 
 ## Testing
-Run all five reference targets and verify output (no aborts, port masks match convention):
+Run all five reference targets and verify output — no aborts, port masks match convention, timers resolve:
 ```
 ./convert.sh FOXEERF722V4 ./test
 ./convert.sh TUNERCF405 ./test
@@ -64,14 +19,3 @@ Run all five reference targets and verify output (no aborts, port masks match co
 ./convert.sh PYRODRONEF7 ./test
 ./convert.sh SKYSTARSF405AIO ./test
 ```
-Check: port masks are `0xffff` for multi-pin ports and `(BIT(n))` for single-pin ports, timers resolve (no `UNKNOWN_TIM`), no aborts.
-
-## Known Limitations
-- H7 ADC DMA streams: not resolved (H7 uses DMAMUX, not fixed assignments); output includes "please verify" notices
-- Dual-gyro targets: GYRO_1/GYRO_2 assignments may need post-convert validation
-- SPI RX (ELRS, FrSky): partial automation; manual completion needed
-- GPS: skipped entirely
-- VTX RTC6705: skipped; add manually if needed
-- `DEFAULT_VOLTAGE_METER_SCALE` not captured (pre-existing gap)
-- `USB_DETECT_PIN` define not emitted alongside `USE_USB_DETECT` (pre-existing gap)
-- Always search output files for keyword `notice` to find items needing manual attention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Imported Rules
+@AGENTS.md
+@.github/instructions/workflow.instructions.md

--- a/info/CONVERTER_DESIGN.md
+++ b/info/CONVERTER_DESIGN.md
@@ -23,7 +23,7 @@ The old `betaflight/unified-targets` repo (`.config` files, `VEND-TARGETNAME` fo
 
 CSV format: comma-separated, `#` comment lines skipped.
 
-### Timer hardware tables (`f4_timer_hw.csv`, `f7_timer_hw.csv`)
+### Timer hardware tables (`f4_timer_hw.csv`, `f7_timer_hw.csv`, `h7_timer_hw.csv`)
 
 ```
 # pin,occurrence,TIM,CH
@@ -32,8 +32,9 @@ PA0,2,TIM5,CH1
 ```
 
 - `occurrence` = which timer this pin maps to in priority order (matches the occurrence index in Betaflight's `TIMER_PIN_MAP`)
-- Generated from `timer_stm32f4xx.c` / `timer_stm32f7xx.c` in the Betaflight source
+- Generated from `timer_stm32f4xx.c` / `timer_stm32f7xx.c` / `timer_stm32h7xx.c` in the Betaflight source
 - Key in associative array: `PIN_occurrence` → `TIMx:CHy`
+- H7 note: TIM9/TIM10/TIM11 are absent on H7; TIM15/TIM16/TIM17 are present instead
 
 ### DMA tables (`f4f7_dma_adc.csv`, `f4f7_dma_timer.csv`, `f4f7_dma_spi.csv`)
 
@@ -49,6 +50,20 @@ PA0,2,TIM5,CH1
 
 See `tools/gen_lookup_tables.sh` — requires a local Betaflight source tree.
 
+## MCU family routing
+
+| Betaflight MCU | Timer CSV | `TARGET_BOARD_IDENTIFIER` | Make target group |
+|---|---|---|---|
+| STM32F405 | `f4_timer_hw.csv` | `S405` | `F405_TARGETS` |
+| STM32F411 | `f4_timer_hw.csv` | `S411` | `F411_TARGETS` |
+| STM32F446 | `f4_timer_hw.csv` | `S446` | `F446_TARGETS` |
+| STM32F7X2 | `f7_timer_hw.csv` | `S7X2` | `F7X2RE_TARGETS` |
+| STM32F745 | `f7_timer_hw.csv` | `S745` | `F7X5XG_TARGETS` |
+| STM32H723/H725 | `h7_timer_hw.csv` | `SH72` | `H723_TARGETS` |
+| STM32H730 | `h7_timer_hw.csv` | `S730` | `H730_TARGETS` |
+| STM32H743 | `h7_timer_hw.csv` | `SH74` | `H743_TARGETS` |
+| STM32H750 | `h7_timer_hw.csv` | `S750` | `H750_TARGETS` |
+
 ## Timer resolution (TIMER_PIN_MAP)
 
 Betaflight `config.h` contains:
@@ -61,10 +76,11 @@ Betaflight `config.h` contains:
 Format: `TIMER_PIN_MAP(index, PIN, occurrence, dmaopt)`
 
 The converter:
-1. Parses all `TIMER_PIN_MAP()` entries from `config.h`
-2. Looks up `PIN + occurrence` in the timer CSV to get `TIMx:CHy`
-3. Determines `TIM_USE_*` role from pin's define in config.h (MOTOR_PIN, PPM_PIN, LED_STRIP_PIN, CAMERA_CONTROL_PIN)
-4. Emits `DEF_TIM(TIMx, CHy, PIN, TIM_USE_xxx, 0, dmaopt)` in `target.c`
+1. Filters comment lines (`^\s*//`) — some configs include a `// TIMER_PIN_MAP(...)` header comment that matches the grep pattern
+2. Resolves macro pin names — H7 targets (and some others) use macro names like `MOTOR1_PIN` instead of literal pin values like `PC6`; the converter looks up `#define MACRONAME PIN` in config.h before doing the timer table lookup
+3. Looks up `PIN + occurrence` in the timer CSV to get `TIMx:CHy`
+4. Determines `TIM_USE_*` role from pin's define in config.h (MOTOR1..8_PIN → `TIM_USE_MOTOR`, SERVO1..4_PIN → `TIM_USE_SERVO`, PPM_PIN → `TIM_USE_PPM`, LED_STRIP_PIN → `TIM_USE_LED`, CAMERA_CONTROL_PIN → `TIM_USE_ANY`)
+5. Emits `DEF_TIM(TIMx, CHy, PIN, TIM_USE_xxx, 0, dmaopt)` in `target.c`
 
 ## GYRO SPI naming
 
@@ -92,10 +108,10 @@ The converter translates these automatically.
 
 ## Known limitations / manual review required
 
-- Dual-gyro targets: GYRO_1/GYRO_2 pin assignments may need validation
+- Dual-gyro targets: GYRO_1/GYRO_2 pin assignments may need validation; quad-gyro targets (e.g. STELLARH7DEV) require post-convert manual reduction to the one EmuFlight-supported gyro
+- H7 ADC DMA streams: not resolved — H7 uses DMAMUX (no fixed opt→stream mapping); output includes "please verify" notices
 - SPI RX (ELRS, FrSky): partially automated, manual completion needed
 - VTX RTC6705: skipped entirely, add manually if needed
 - GPS: skipped
-- ADC DMA streams: computed but marked with "please verify"
 - Some rare peripheral combinations not accounted for
 - Always search output files for the keyword `notice` to find items needing manual attention

--- a/info/PORT_MASKS.md
+++ b/info/PORT_MASKS.md
@@ -41,13 +41,14 @@ The Perl script `src/utils/def_generated.pl` generates `io_def_generated.h` at b
 
 ## How convert.sh computes masks
 
-1. Scans `config.h` for all `P[A-H][0-9]{1,2}` tokens
+1. Scans `config.h` for all `P[A-K][0-9]{1,2}` tokens (A–K covers H7)
 2. Groups by port letter, ORs `(1 << pin_number)` per port
 3. Power-of-2 check `(mask & (mask-1)) == 0` → single pin → emit `(BIT(n))`
 4. Otherwise emit `0xffff`
+5. Loops ports A–K; skips any port with zero mask (so unused H7 ports I/J/K don't appear on F4/F7 targets)
 
 ## Port letters by MCU family
 
 - F4, F7: ports A–H (some boards only use A–D or A–E)
-- H7: ports A–K (adds I, J, K) — needs extension when H7 support is added
+- H7: ports A–K (adds I, J, K) — supported
 - G4: ports A–G typically


### PR DESCRIPTION
## Summary
- **\`AGENTS.md\`** — source of truth for AI agents: project overview, scope constraint (`convert.sh` + `lookup/*.csv` only), test procedure; references `@info/CONVERTER_DESIGN.md` and `@info/PORT_MASKS.md` for technical detail
- **\`CLAUDE.md\`** — minimal pointer file; `@imports` `AGENTS.md` and `.github/instructions/workflow.instructions.md` so Claude Code loads both automatically
- **\`info/CONVERTER_DESIGN.md\`** — full technical reference: MCU routing table, TIMER_PIN_MAP resolution, SPI naming, DMA tables, output files, known limitations
- **\`info/PORT_MASKS.md\`** — port mask convention, BIT(n) vs 0xffff rule, H7 port A–K support
- **\`.gitignore\`** — allowlist `!CLAUDE.md` and `!AGENTS.md`

## Agent loading behaviour
| Tool | AGENTS.md | CLAUDE.md | workflow.instructions.md |
|---|---|---|---|
| Claude Code | via CLAUDE.md @import | auto | via CLAUDE.md @import |
| VS Code Copilot | **not automatic** — use `#file:AGENTS.md` in chat | n/a | auto (`applyTo: "**"`) |

VS Code Copilot does not auto-load AGENTS.md. It does auto-load `.github/instructions/*.instructions.md` files (already set up). Mention `#file:AGENTS.md` in Copilot Chat when you want the technical reference in context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)