### PR TITLE
fix(convert): output BF-aligned scale define names

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -1103,10 +1103,10 @@ done
 echo ' - please verify ADC DMA Streams.'
 grep "DEFAULT_VOLTAGE_METER_SOURCE" $config >> ${hFile}
 scale=$(grep "DEFAULT_VOLTAGE_METER_SCALE" $config | awk '{print $3}')
-[[ -n "$scale" ]] && echo "#define VBAT_SCALE_DEFAULT $scale" >> ${hFile}
+[[ -n "$scale" ]] && echo "#define DEFAULT_VOLTAGE_METER_SCALE $scale" >> ${hFile}
 grep "DEFAULT_CURRENT_METER_SOURCE" $config >> ${hFile}
 curscale=$(grep "DEFAULT_CURRENT_METER_SCALE" $config | awk '{print $3}')
-[[ -n "$curscale" ]] && echo "#define CURRENT_METER_SCALE_DEFAULT $curscale" >> ${hFile}
+[[ -n "$curscale" ]] && echo "#define DEFAULT_CURRENT_METER_SCALE $curscale" >> ${hFile}
 grep ADC_INSTANCE $config >> ${hFile}
 echo '' >> ${hFile}
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Fixes `convert.sh` to output `#define DEFAULT_VOLTAGE_METER_SCALE` instead of the old `VBAT_SCALE_DEFAULT`
- Fixes `convert.sh` to output `#define DEFAULT_CURRENT_METER_SCALE` instead of the old `CURRENT_METER_SCALE_DEFAULT`
- EmuFlight target.h files and firmware sources (voltage.c, current.c) now use BF 4.5-maintenance-aligned symbol names; generated targets must match

## Test plan

- [ ] Run `convert.sh` against a BF config that includes `DEFAULT_VOLTAGE_METER_SCALE` and `DEFAULT_CURRENT_METER_SCALE` entries
- [ ] Confirm the generated `target.h` contains `#define DEFAULT_VOLTAGE_METER_SCALE <value>` (not `VBAT_SCALE_DEFAULT`)
- [ ] Confirm the generated `target.h` contains `#define DEFAULT_CURRENT_METER_SCALE <value>` (not `CURRENT_METER_SCALE_DEFAULT`)
- [ ] Verify the generated target compiles cleanly against the updated EmuFlight firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)