### PR TITLE
feat(convert): NAND flash, multi-chip, and CS-pin-only detection

### DIFF
--- a/convert.sh
+++ b/convert.sh
@@ -258,9 +258,18 @@ fi
 
 # enable flash and drivers
 FEATURES='FEATURES       += VCP '
-if [[ $(grep SDCARD $config) ]]; then
+if [[ $(grep 'USE_SDCARD' $config) ]]; then
     FEATURES+='SDCARD'
-else
+fi
+if [[ $(grep 'USE_FLASH' $config) ]]; then
+    if [[ $FEATURES == *'SDCARD'* ]]; then
+        FEATURES+=' ONBOARDFLASH'
+    else
+        FEATURES+='ONBOARDFLASH'
+    fi
+fi
+if [[ $FEATURES == 'FEATURES       += VCP ' ]]; then
+    # No flash or sdcard detected; default to ONBOARDFLASH
     FEATURES+='ONBOARDFLASH'
 fi
 echo "${FEATURES}" >> ${mkFile}
@@ -621,9 +630,31 @@ fi
 echo '' >> ${hFile}
 
 echo '#define USE_VCP' >> ${hFile}
-if [[ $(grep USE_FLASH $config) ]] ; then
+if [[ $(grep 'USE_FLASH' $config) ]] ; then
     echo '#define USE_FLASHFS' >> ${hFile}
-    echo '#define USE_FLASH_M25P16    // 16MB Micron M25P16 driver; drives all unless QSPI' >> ${hFile}
+    # Detect NOR vs NAND flash chip types from BF config
+    has_nor=$(grep -E 'USE_FLASH_(W25Q128FV|M25P16|W25M512|PY25Q128HA)' $config 2>/dev/null)
+    has_nand=$(grep -E 'USE_FLASH_(W25N01G|W25N02K|W25M02G)' $config 2>/dev/null)
+    if [[ $has_nor || ! $has_nand ]] ; then
+        # NOR or unknown chip: emit NOR driver
+        if [[ $(grep 'USE_FLASH_W25Q128FV' $config) ]] ; then
+            echo '#define USE_FLASH_W25Q128FV' >> ${hFile}
+        fi
+        if [[ $(grep 'USE_FLASH_W25M512' $config) ]] ; then
+            echo '#define USE_FLASH_W25M512' >> ${hFile}
+        fi
+        echo '#define USE_FLASH_M25P16    // 16MB Micron M25P16 driver; drives all unless QSPI' >> ${hFile}
+    fi
+    # NAND chips
+    if [[ $(grep 'USE_FLASH_W25M02G' $config) ]] ; then
+        echo '#define USE_FLASH_W25M02G' >> ${hFile}
+    fi
+    if [[ $(grep 'USE_FLASH_W25N01G' $config) ]] ; then
+        echo '#define USE_FLASH_W25N01G' >> ${hFile}
+    fi
+    if [[ $(grep 'USE_FLASH_W25N02K' $config) ]] ; then
+        echo '#define USE_FLASH_W25N02K' >> ${hFile}
+    fi
 fi
 if [[ $(grep USE_MAX7456 $config) ]] ; then
     echo '#define USE_OSD' >> ${hFile}

--- a/convert.sh
+++ b/convert.sh
@@ -261,7 +261,7 @@ FEATURES='FEATURES       += VCP '
 if [[ $(grep 'USE_SDCARD' $config) ]]; then
     FEATURES+='SDCARD'
 fi
-if [[ $(grep 'USE_FLASH' $config) ]]; then
+if [[ $(grep 'USE_FLASH' $config) || $(grep 'FLASH_CS_PIN' $config) ]]; then
     if [[ $FEATURES == *'SDCARD'* ]]; then
         FEATURES+=' ONBOARDFLASH'
     else
@@ -630,13 +630,13 @@ fi
 echo '' >> ${hFile}
 
 echo '#define USE_VCP' >> ${hFile}
-if [[ $(grep 'USE_FLASH' $config) ]] ; then
+if [[ $(grep 'USE_FLASH' $config) || $(grep 'FLASH_CS_PIN' $config) ]] ; then
     echo '#define USE_FLASHFS' >> ${hFile}
     # Detect NOR vs NAND flash chip types from BF config
     has_nor=$(grep -E 'USE_FLASH_(W25Q128FV|M25P16|W25M512|PY25Q128HA)' $config 2>/dev/null)
     has_nand=$(grep -E 'USE_FLASH_(W25N01G|W25N02K|W25M02G)' $config 2>/dev/null)
     if [[ $has_nor || ! $has_nand ]] ; then
-        # NOR or unknown chip: emit NOR driver
+        # NOR or unknown chip (including FLASH_CS_PIN-only configs): emit NOR driver
         if [[ $(grep 'USE_FLASH_W25Q128FV' $config) ]] ; then
             echo '#define USE_FLASH_W25Q128FV' >> ${hFile}
         fi
@@ -1094,7 +1094,7 @@ echo '' >> ${hFile}
 
 ## flash
 echo "building FLASH"
-if [[ $(grep 'USE_FLASH' $config) ]] ; then
+if [[ $(grep 'USE_FLASH' $config) || $(grep 'FLASH_CS_PIN' $config) ]] ; then
     grep FLASH_CS_PIN $config >> ${hFile}
     grep FLASH_SPI_INSTANCE $config >> ${hFile}
     translate "BLACKBOX_DEVICE_FLASH" $config '#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT' ${hFile}


### PR DESCRIPTION
AI Generated pull-request

## Summary

- **NAND flash and multi-chip support**: previously `convert.sh` always emitted `USE_FLASH_M25P16` for any target with `USE_FLASH`. Now reads chip-specific defines from the BF unified-target config:
  - `USE_FLASH_W25Q128FV` → emit `USE_FLASH_W25Q128FV` + `USE_FLASH_M25P16` (W25Q128FV is the chip identifier; M25P16 is the SPI driver — the dedicated QuadSPI driver only activates when `USE_QUADSPI` is defined)
  - `USE_FLASH_W25M512` → emit `USE_FLASH_W25M512` + `USE_FLASH_M25P16`
  - NOR/unknown → emit `USE_FLASH_M25P16` (JEDEC auto-detection)
  - NAND-only boards (`W25N01G`, `W25N02K`, `W25M02G`): emitted without M25P16 (wrong driver family)
  - Mixed NOR+NAND boards: both NOR driver and NAND chip defines emitted
- **`FLASH_CS_PIN`-only BF configs**: some BF configs declare flash hardware with only `FLASH_CS_PIN` + `FLASH_SPI_INSTANCE`, omitting an explicit `USE_FLASH`. BF handles this via `common_pre.h` default — EF requires an explicit chip define. All three flash trigger conditions updated to `grep 'USE_FLASH' || grep 'FLASH_CS_PIN'` so pin-only configs produce correct output.
- **SDCARD + ONBOARDFLASH coexistence**: previously mutually exclusive (SDCARD *or* ONBOARDFLASH). H7 AIO boards commonly have both. Now each feature is detected independently.

## Test plan

- [ ] Convert a `W25Q128FV` target (e.g. FPVM\_BETAFLIGHTF7 config): confirm `USE_FLASH_W25Q128FV` + `USE_FLASH_M25P16` in output
- [ ] Convert a NAND-only target (e.g. ALIENFLIGHTNGF7 config): confirm `USE_FLASH_W25N01G`, no `USE_FLASH_M25P16`
- [ ] Convert a mixed NOR+NAND target (e.g. IFLIGHT\_F722\_TWING config): confirm M25P16 + W25M512 + W25N01G
- [ ] Convert a pin-only config (e.g. OMNIBUSF4V6): confirm M25P16 + pins in output, ONBOARDFLASH in .mk
- [ ] Convert an SDIO + flash board (e.g. NEUTRONRCH743AIO): confirm `FEATURES += VCP SDCARD ONBOARDFLASH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional flash memory chip models in NOR and NAND configurations.
  * Improved automatic detection and configuration of flash and SDcard storage options based on board settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->